### PR TITLE
Various changes to work on non-FHS distros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install:
 	git rev-parse --short HEAD > $(ver)
 	mkdir -p ~/.local/share/ptSh
 	cp src/config ~/.local/share/ptSh/config
-	cp src/set_aliases.sh ~/.local/bin/ptSh_set_aliases # should this be added to PATH? it could be added to .bashrc instead
+	cp src/set_aliases.sh ~/.local/bin/ptSh_set_aliases
 	cp src/ptsh.sh ~/.local/bin/ptsh
 	cp LICENSE ~/.local/share/ptSh/LICENSE
 	cp src/logo.txt ~/.local/share/ptSh/logo.txt

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 ver=/tmp/ptsh_ver
 install:
 	git rev-parse --short HEAD > $(ver)
-	sudo mkdir -p ~/.local/share/ptSh
-	sudo cp src/config ~/.local/share/ptSh/config
-	sudo cp src/set_aliases.sh ~/.local/bin/ptSh_set_aliases
-	sudo cp src/ptsh.sh ~/.local/bin/ptsh
-	sudo cp LICENSE ~/.local/share/ptSh/LICENSE
-	sudo cp src/logo.txt ~/.local/share/ptSh/logo.txt
-	sudo cp src/ptLs.sh ~/.local/bin/ptls
-	sudo cp src/ptPwd.sh ~/.local/bin/ptpwd
-	sudo cp src/ptMkdir.sh ~/.local/bin/ptmkdir
-	sudo cp src/ptTouch.sh ~/.local/bin/pttouch
+	mkdir -p ~/.local/share/ptSh
+	cp src/config ~/.local/share/ptSh/config
+	cp src/set_aliases.sh ~/.local/bin/ptSh_set_aliases
+	cp src/ptsh.sh ~/.local/bin/ptsh
+	cp LICENSE ~/.local/share/ptSh/LICENSE
+	cp src/logo.txt ~/.local/share/ptSh/logo.txt
+	cp src/ptLs.sh ~/.local/bin/ptls
+	cp src/ptPwd.sh ~/.local/bin/ptpwd
+	cp src/ptMkdir.sh ~/.local/bin/ptmkdir
+	cp src/ptTouch.sh ~/.local/bin/pttouch
 	mkdir -p ~/.config
 	mkdir -p ~/.config/ptSh
 	cp src/config ~/.config/ptSh/config
-	echo "Version: cloned from " | sudo tee ~/.local/share/ptSh/version.txt
-	cat $(ver) | sudo tee -a ~/.local/share/ptSh/version.txt
+	echo "Version: cloned from " | tee ~/.local/share/ptSh/version.txt
+	cat $(ver) | tee -a ~/.local/share/ptSh/version.txt
 	ptsh

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ install:
 	cp src/config ~/.local/share/ptSh/config
 	mkdir -p ~/.local/bin
 	cp src/set_aliases.sh ~/.local/bin/ptSh_set_aliases
-	cp src/ptsh.sh ~/.local/bin/ptsh
 	cp LICENSE ~/.local/share/ptSh/LICENSE
 	cp src/logo.txt ~/.local/share/ptSh/logo.txt
 	cp src/ptLs.sh ~/.local/bin/ptls
@@ -21,13 +20,12 @@ install:
 	cp src/config ~/.config/ptSh/config
 	echo "Version: cloned from " | tee ~/.local/share/ptSh/version.txt
 	cat $(ver) | tee -a ~/.local/share/ptSh/version.txt
-	ptsh
+	src/ptsh.sh
 
 uninstall:
 	rm -rf ~/.local/share/ptSh
 	rm -rf ~/.config/ptSh
 	rm ~/.local/bin/ptSh_set_aliases
-	rm ~/.local/bin/ptsh
 	rm ~/.local/bin/ptls
 	rm ~/.local/bin/ptpwd
 	rm ~/.local/bin/ptmkdir

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 ver=/tmp/ptsh_ver
 install:
 	git rev-parse --short HEAD > $(ver)
-	sudo mkdir -p /usr/local/share/ptSh
-	sudo cp src/config /usr/local/share/ptSh/config
-	sudo cp src/set_aliases.sh /usr/local/bin/ptSh_set_aliases
-	sudo cp src/ptsh.sh /usr/local/bin/ptsh
-	sudo cp LICENSE /usr/local/share/ptSh/LICENSE
-	sudo cp src/logo.txt /usr/local/share/ptSh/logo.txt
-	sudo cp src/ptLs.sh /usr/local/bin/ptls
-	sudo cp src/ptPwd.sh /usr/local/bin/ptpwd
-	sudo cp src/ptMkdir.sh /usr/local/bin/ptmkdir
-	sudo cp src/ptTouch.sh /usr/local/bin/pttouch
+	sudo mkdir -p ~/.local/share/ptSh
+	sudo cp src/config ~/.local/share/ptSh/config
+	sudo cp src/set_aliases.sh ~/.local/bin/ptSh_set_aliases
+	sudo cp src/ptsh.sh ~/.local/bin/ptsh
+	sudo cp LICENSE ~/.local/share/ptSh/LICENSE
+	sudo cp src/logo.txt ~/.local/share/ptSh/logo.txt
+	sudo cp src/ptLs.sh ~/.local/bin/ptls
+	sudo cp src/ptPwd.sh ~/.local/bin/ptpwd
+	sudo cp src/ptMkdir.sh ~/.local/bin/ptmkdir
+	sudo cp src/ptTouch.sh ~/.local/bin/pttouch
 	mkdir -p ~/.config
 	mkdir -p ~/.config/ptSh
 	cp src/config ~/.config/ptSh/config
-	echo "Version: cloned from " | sudo tee /usr/local/share/ptSh/version.txt
-	cat $(ver) | sudo tee -a /usr/local/share/ptSh/version.txt
+	echo "Version: cloned from " | sudo tee ~/.local/share/ptSh/version.txt
+	cat $(ver) | sudo tee -a ~/.local/share/ptSh/version.txt
 	ptsh

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,13 @@ install:
 	cp src/ptPwd.sh ~/.local/bin/ptpwd
 	cp src/ptMkdir.sh ~/.local/bin/ptmkdir
 	cp src/ptTouch.sh ~/.local/bin/pttouch
+	cp src/ptsh.sh ~/.local/bin/ptsh
 	mkdir -p ~/.config
 	mkdir -p ~/.config/ptSh
 	cp src/config ~/.config/ptSh/config
 	echo "Version: cloned from " | tee ~/.local/share/ptSh/version.txt
 	cat $(ver) | tee -a ~/.local/share/ptSh/version.txt
-	src/ptsh.sh
+	~/.local/bin/ptsh
 
 uninstall:
 	rm -rf ~/.local/share/ptSh

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 ver=/tmp/ptsh_ver
+
+all:
+	@echo Run \'make install\'
+
 install:
 	git rev-parse --short HEAD > $(ver)
 	mkdir -p ~/.local/share/ptSh
 	cp src/config ~/.local/share/ptSh/config
-	cp src/set_aliases.sh ~/.local/bin/ptSh_set_aliases
+	cp src/set_aliases.sh ~/.local/bin/ptSh_set_aliases # should this be added to PATH? it could be added to .bashrc instead
 	cp src/ptsh.sh ~/.local/bin/ptsh
 	cp LICENSE ~/.local/share/ptSh/LICENSE
 	cp src/logo.txt ~/.local/share/ptSh/logo.txt
@@ -17,3 +21,13 @@ install:
 	echo "Version: cloned from " | tee ~/.local/share/ptSh/version.txt
 	cat $(ver) | tee -a ~/.local/share/ptSh/version.txt
 	ptsh
+
+uninstall:
+	rm -rf ~/.local/share/ptSh
+	rm -rf ~/.config/ptSh
+	rm ~/.local/bin/ptSh_set_aliases
+	rm ~/.local/bin/ptsh
+	rm ~/.local/bin/ptls
+	rm ~/.local/bin/ptpwd
+	rm ~/.local/bin/ptmkdir
+	rm ~/.local/bin/pttouch

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ install:
 	git rev-parse --short HEAD > $(ver)
 	mkdir -p ~/.local/share/ptSh
 	cp src/config ~/.local/share/ptSh/config
+	mkdir -p ~/.local/bin
 	cp src/set_aliases.sh ~/.local/bin/ptSh_set_aliases
 	cp src/ptsh.sh ~/.local/bin/ptsh
 	cp LICENSE ~/.local/share/ptSh/LICENSE

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ You can customize ptSh scripts in many ways. Config file is in `/home/$USER/.con
 
 You need to install a font, that supports unicode special symbols, like [NerdFonts](https://github.com/ryanoasis/nerd-fonts).
 
+Make sure `~/.local/bin` is in PATH
+
 #### Automated installation
 
 Just download an installation script from [releases](https://github.com/jszczerbinsky/ptSh/releases) and run it.

--- a/README.md
+++ b/README.md
@@ -1,35 +1,41 @@
-### About
+# ptSh
 
 ptSh is a packet of shell scripts, that run standard shell commands and display them in a prettier way.
 
-### Features
+## Features
 
 Currently available scripts:
 
-| Script name | Corresponding command | Available arguments |
-| ------------ | ------------ | ------------ |
-| `ptls` |  `ls` | `-l`, `-a`, `-A` |
-| `ptpwd` | `pwd` | all |
-| `ptmkdir` | `mkdir` | all |
-| `pttouch` | `touch` | all |
+| Script name  | Corresponding command | Available arguments |
+| ------------ | ------------          | ------------        |
+| `ptls`       | `ls`                  | `-l`, `-a`, `-A`    |
+| `ptpwd`      | `pwd`                 | all                 |
+| `ptmkdir`    | `mkdir`               | all                 |
+| `pttouch`    | `touch`               | all                 |
 
 You can customize ptSh scripts in many ways. Config file is in `/home/$USER/.config/ptSh/config`.
 
-### Installation
+## Installation
 
 You need to install a font, that supports unicode special symbols, like [NerdFonts](https://github.com/ryanoasis/nerd-fonts).
 
-Make sure `~/.local/bin` is in PATH
+## Via [Rookie Package Manger](https://github.com/18fadly-anthony/rookie)
 
-#### Automated installation
+```
+rookie.py --install ptSh
+```
+
+### Automated installation
 
 Just download an installation script from [releases](https://github.com/jszczerbinsky/ptSh/releases) and run it.
 
-#### Manual installation
+### Manual installation
+
+Make sure `~/.local/bin` is in PATH
 
 Clone this repository and use `make` to install it.
 
-### Configuration
+## Configuration
 
 If you want to use ptSh scripts by default you can set aliases in your `.bashrc` file.
 To automatically set all ptSh aliases, add this to your `.bashrc`:
@@ -40,7 +46,7 @@ source ptSh_set_aliases
 
 You can configure colors, messages etc. in config file: `/home/$USER/.config/ptSh/config`
 
-### Some screenshots
+## Screenshots
 
 ![](/img/ptls.png)
 ![](/img/ptpwd.png)

--- a/src/config
+++ b/src/config
@@ -1,5 +1,5 @@
 # This is ptSh config file
-# You can find default config file in /usr/local/share/ptSh/config
+# You can find default config file in ~/.local/share/ptSh/config
 # You should not override default config file
 # Path to your config file should be /home/$USER/.config/ptSh/config
 

--- a/src/config
+++ b/src/config
@@ -25,18 +25,18 @@ SUCCESS_MESSAGE='Done'                        # Success message
 # Escape codes
 # You can set ansi escape codes, that will be displayed before prefixes or names to give them effects, such as color
 #
-DIR_PREFIX_ESCAPE_CODES='\e[35m'              # Escape codes for directory prefix
-FILE_PREFIX_ESCAPE_CODES='\e[94m'             # Escape codes for file prefix
-LINK_PREFIX_ESCAPE_CODES='\e[36m'             # Escape codes for link prefix
+DIR_PREFIX_ESCAPE_CODES='\x1B[35m'            # Escape codes for directory prefix
+FILE_PREFIX_ESCAPE_CODES='\x1B[94m'           # Escape codes for file prefix
+LINK_PREFIX_ESCAPE_CODES='\x1B[36m'           # Escape codes for link prefix
 
 DIR_NAME_ESCAPE_CODES=''                      # Escape codes for directory name
 FILE_NAME_ESCAPE_CODES=''                     # Escape codes for file name
 LINK_NAME_ESCAPE_CODES=''                     # Escape codes for link name
 
-ERROR_PREFIX_ESCAPE_CODES='\e[91m'            # Escape codes for error prefix
+ERROR_PREFIX_ESCAPE_CODES='\x1B[91m'            # Escape codes for error prefix
 ERROR_MESSAGE_ESCAPE_CODES=''                 # Escape codes for error message
 
-SUCCESS_PREFIX_ESCAPE_CODES='\e[92m'          # Escape codes for success prefix
+SUCCESS_PREFIX_ESCAPE_CODES='\x1B[92m'          # Escape codes for success prefix
 SUCCESS_MESSAGE_ESCAPE_CODES=''               # Escape codes for success message
 
 #

--- a/src/ptLs.sh
+++ b/src/ptLs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source /usr/local/share/ptSh/config
 test -f ~/.config/ptSh/config && source ~/.config/ptSh/config

--- a/src/ptLs.sh
+++ b/src/ptLs.sh
@@ -64,14 +64,14 @@ while read -r line; do
     link=false
 
     if [[ ${words[0]} == "d"* ]]; then
-        filename="${DIR_PREFIX_ESCAPE_CODES}${DIR_PREFIX}\e[0m${DIR_NAME_ESCAPE_CODES}"
+        filename="${DIR_PREFIX_ESCAPE_CODES}${DIR_PREFIX}\x1B[0m${DIR_NAME_ESCAPE_CODES}"
         prefixLength=${#DIR_PREFIX}
     elif [[ ${words[0]} == "l"* ]];then
-        filename="${LINK_PREFIX_ESCAPE_CODES}${LINK_PREFIX}\e[0m${LINK_NAME_ESCAPE_CODES}"
+        filename="${LINK_PREFIX_ESCAPE_CODES}${LINK_PREFIX}\x1B[0m${LINK_NAME_ESCAPE_CODES}"
         prefixLength=${#LINK_PREFIX}
         link=true
     else
-        filename="${FILE_PREFIX_ESCAPE_CODES}${FILE_PREFIX}\e[0m${FILE_NAME_ESCAPE_CODES}"
+        filename="${FILE_PREFIX_ESCAPE_CODES}${FILE_PREFIX}\x1B[0m${FILE_NAME_ESCAPE_CODES}"
         prefixLength=${#FILE_PREFIX}
     fi
 
@@ -89,7 +89,7 @@ while read -r line; do
     
     nameLength=$((nameLength-1))
     filename="${filename::-1}"
-    filename="$filename\e[0m"
+    filename="$filename\x1B[0m"
     
     actualChar=$((nameLength+prefixLength))
     

--- a/src/ptLs.sh
+++ b/src/ptLs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source /usr/local/share/ptSh/config
+source ~/.local/share/ptSh/config
 test -f ~/.config/ptSh/config && source ~/.config/ptSh/config
 
 columnSize=0

--- a/src/ptMkdir.sh
+++ b/src/ptMkdir.sh
@@ -22,21 +22,21 @@ for val in "${words[@]}"; do
 done
 
 for name in "${names[@]}"; do
-    echo -ne "${DIR_PREFIX_ESCAPE_CODES}${DIR_PREFIX}\e[0m"
-    echo -e "${DIR_NAME_ESCAPE_CODES}$name\e[0m"
+    echo -ne "${DIR_PREFIX_ESCAPE_CODES}${DIR_PREFIX}\x1B[0m"
+    echo -e "${DIR_NAME_ESCAPE_CODES}$name\x1B[0m"
     ERR=$(mkdir $args $name 2>&1)
     
     echo -n "└"
 
     while read -r line; do
         if [[ -z $line ]]; then
-            echo -ne "${SUCCESS_PREFIX_ESCAPE_CODES}${SUCCESS_PREFIX}\e[0m"
-            echo -e "${SUCCESS_MESSAGE_ESCAPE_CODES}${SUCCESS_MESSAGE}\e[0m"
+            echo -ne "${SUCCESS_PREFIX_ESCAPE_CODES}${SUCCESS_PREFIX}\x1B[0m"
+            echo -e "${SUCCESS_MESSAGE_ESCAPE_CODES}${SUCCESS_MESSAGE}\x1B[0m"
         else
-            echo -ne "${ERROR_PREFIX_ESCAPE_CODES}${ERROR_PREFIX}\e[0m"
+            echo -ne "${ERROR_PREFIX_ESCAPE_CODES}${ERROR_PREFIX}\x1B[0m"
             echo -ne "${ERROR_MESSAGE_ESCAPE_CODES}"
             echo -n "$(echo "$line" | sed "s/$1: //g" | sed 's/^[^:]*://g')"
-            echo -e "\e[0m"
+            echo -e "\x1B[0m"
         fi
     done <<< "$ERR"
 done

--- a/src/ptMkdir.sh
+++ b/src/ptMkdir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source /usr/local/share/ptSh/config
 test -f ~/.config/ptSh/config && source ~/.config/ptSh/config

--- a/src/ptMkdir.sh
+++ b/src/ptMkdir.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source /usr/local/share/ptSh/config
+source ~/.local/share/ptSh/config
 test -f ~/.config/ptSh/config && source ~/.config/ptSh/config
 
 if [[ -z $1 ]] || [[ $1 == "--help" ]]; then

--- a/src/ptPwd.sh
+++ b/src/ptPwd.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source /usr/local/share/ptSh/config
+source ~/.local/share/ptSh/config
 test -f ~/.config/ptSh/config && source ~/.config/ptSh/config
 
 function setval { printf -v "$1" "%s" "$(cat)"; declare -p "$1"; }

--- a/src/ptPwd.sh
+++ b/src/ptPwd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source /usr/local/share/ptSh/config
 test -f ~/.config/ptSh/config && source ~/.config/ptSh/config

--- a/src/ptPwd.sh
+++ b/src/ptPwd.sh
@@ -8,8 +8,8 @@ function setval { printf -v "$1" "%s" "$(cat)"; declare -p "$1"; }
 eval "$(pwd $@ 2> >(setval err) > >(setval std) )"
 
 if [[ ! -z $err ]]; then
-    echo -ne "${ERROR_PREFIX_ESCAPE_CODES}${ERROR_PREFIX}\e[0m"
-    echo -e "${ERROR_MESSAGE_ESCAPE_CODES}$err\e[0m"
+    echo -ne "${ERROR_PREFIX_ESCAPE_CODES}${ERROR_PREFIX}\x1B[0m"
+    echo -e "${ERROR_MESSAGE_ESCAPE_CODES}$err\x1B[0m"
     exit
 fi
 
@@ -25,12 +25,12 @@ spaces=0
 function displayDir(){
 
     if $2; then
-        echo -ne "${PWD_LINE_ESCAPE_CODES}└ \e[0m"
+        echo -ne "${PWD_LINE_ESCAPE_CODES}└ \x1B[0m"
     fi
     if ((PWD_SHOW_DIR_PREFIX == 1)); then
-        echo -ne "${DIR_PREFIX_ESCAPE_CODES}${DIR_PREFIX}\e[0m"
+        echo -ne "${DIR_PREFIX_ESCAPE_CODES}${DIR_PREFIX}\x1B[0m"
     fi
-    echo -e "${DIR_NAME_ESCAPE_CODES}$1\e[0m"
+    echo -e "${DIR_NAME_ESCAPE_CODES}$1\x1B[0m"
 }
 
 displayDir "/" false

--- a/src/ptTouch.sh
+++ b/src/ptTouch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source /usr/local/share/ptSh/config
 test -f ~/.config/ptSh/config && source ~/.config/ptSh/config

--- a/src/ptTouch.sh
+++ b/src/ptTouch.sh
@@ -22,8 +22,8 @@ for val in "${words[@]}"; do
 done
 
 for name in "${names[@]}"; do
-    echo -ne "${FILE_PREFIX_ESCAPE_CODES}${FILE_PREFIX}\e[0m"
-    echo -e "${FILE_NAME_ESCAPE_CODES}$name\e[0m"
+    echo -ne "${FILE_PREFIX_ESCAPE_CODES}${FILE_PREFIX}\x1B[0m"
+    echo -e "${FILE_NAME_ESCAPE_CODES}$name\x1B[0m"
     echo -n "└"
 
     if [[ -z $args ]] && readlink -e $name >/dev/null; then
@@ -34,13 +34,13 @@ for name in "${names[@]}"; do
 
     while read -r line; do
         if [[ -z $line ]]; then
-            echo -ne "${SUCCESS_PREFIX_ESCAPE_CODES}${SUCCESS_PREFIX}\e[0m"
-            echo -e "${SUCCESS_MESSAGE_ESCAPE_CODES}${SUCCESS_MESSAGE}\e[0m"
+            echo -ne "${SUCCESS_PREFIX_ESCAPE_CODES}${SUCCESS_PREFIX}\x1B[0m"
+            echo -e "${SUCCESS_MESSAGE_ESCAPE_CODES}${SUCCESS_MESSAGE}\x1B[0m"
         else
-            echo -ne "${ERROR_PREFIX_ESCAPE_CODES}${ERROR_PREFIX}\e[0m"
+            echo -ne "${ERROR_PREFIX_ESCAPE_CODES}${ERROR_PREFIX}\x1B[0m"
             echo -ne "${ERROR_MESSAGE_ESCAPE_CODES}"
             echo -n "$(echo "$line" | sed "s/$1: //g" | sed 's/^[^:]*://g')"
-            echo -e "\e[0m"
+            echo -e "\x1B[0m"
         fi
     done <<< "$ERR"
 done

--- a/src/ptTouch.sh
+++ b/src/ptTouch.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source /usr/local/share/ptSh/config
+source ~/.local/share/ptSh/config
 test -f ~/.config/ptSh/config && source ~/.config/ptSh/config
 
 if [[ -z $1 ]] || [[ $1 == "--help" ]]; then

--- a/src/ptsh.sh
+++ b/src/ptsh.sh
@@ -1,7 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo -e "\e[35m"
 
+# TODO /usr/local does not exist on non-FHS distros like NixOS and Guix
+# put this somewhere else
 cat /usr/local/share/ptSh/logo.txt
 
 echo "Let your shell commands look prettier..."

--- a/src/ptsh.sh
+++ b/src/ptsh.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-echo -e "\e[35m"
+echo -e "\x1B[35m"
 
 cat ~/.local/share/ptSh/logo.txt
 
 echo "Let your shell commands look prettier..."
-echo -e "\e[0m"
+echo -e "\x1B[0m"
 
 echo 
 while read -r line; do
@@ -15,7 +15,7 @@ done <<<$(cat ~/.local/share/ptSh/version.txt)
 echo
 echo
 
-echo -e "If You enjoy ptSh, give it a \e[5m\e[93mstar\e[0m on github: \e[92mhttps://github.com/jszczerbinsky/ptSh\e[0m"
-echo -e "\e[34m"
+echo -e "If You enjoy ptSh, give it a \x1B[5m\x1B[93mstar\x1B[0m on github: \x1B[92mhttps://github.com/jszczerbinsky/ptSh\x1B[0m"
+echo -e "\x1B[34m"
 cat ~/.local/share/ptSh/LICENSE
-echo -e "\e[0m"
+echo -e "\x1B[0m"

--- a/src/ptsh.sh
+++ b/src/ptsh.sh
@@ -2,9 +2,7 @@
 
 echo -e "\e[35m"
 
-# TODO /usr/local does not exist on non-FHS distros like NixOS and Guix
-# put this somewhere else
-cat /usr/local/share/ptSh/logo.txt
+cat ~/.local/share/ptSh/logo.txt
 
 echo "Let your shell commands look prettier..."
 echo -e "\e[0m"
@@ -12,12 +10,12 @@ echo -e "\e[0m"
 echo 
 while read -r line; do
     echo -n "$line "
-done <<<$(cat /usr/local/share/ptSh/version.txt)
+done <<<$(cat ~/.local/share/ptSh/version.txt)
 
 echo
 echo
 
 echo -e "If You enjoy ptSh, give it a \e[5m\e[93mstar\e[0m on github: \e[92mhttps://github.com/jszczerbinsky/ptSh\e[0m"
 echo -e "\e[34m"
-cat /usr/local/share/ptSh/LICENSE
+cat ~/.local/share/ptSh/LICENSE
 echo -e "\e[0m"


### PR DESCRIPTION
Not all linux distros put bash in `/bin/bash` and have a `/usr/local`

These changes use `/usr/bin/env bash` and change `/usr/local` to `~/.local` so that it works on all distros and does not require root to install