### PR TITLE
Problem: ptcp would not display 'cp: overwrite file?' message

### DIFF
--- a/src/config
+++ b/src/config
@@ -9,12 +9,13 @@
 # Prefix is displayed before message, file/directory name etc. Prefix can contain multiple chars.
 # If you want to use a special unicode char as prefix, make sure that your terminal's font can display this char.
 #
-DIR_PREFIX=' '                               # Prefix for directories
-FILE_PREFIX=' '                              # Prefix for files
-LINK_PREFIX=' '                             # Prefix for links
+DIR_PREFIX=' '      # Prefix for directories
+FILE_PREFIX=' '     # Prefix for files
+LINK_PREFIX=' '     # Prefix for links
 
-ERROR_PREFIX='  '                            # Prefix displayed before error message
-SUCCESS_PREFIX='  '                          # Prefix displayed before success message
+ERROR_PREFIX='  '   # Prefix displayed before error message
+WARNING_PREFIX='  '  # Prefix displayed before warning message
+SUCCESS_PREFIX='  ' # Prefix displayed before success message
 
 #
 # Messages
@@ -25,19 +26,22 @@ SUCCESS_MESSAGE='Done'                        # Success message
 # Escape codes
 # You can set ansi escape codes, that will be displayed before prefixes or names to give them effects, such as color
 #
-DIR_PREFIX_ESCAPE_CODES='\x1B[35m'            # Escape codes for directory prefix
-FILE_PREFIX_ESCAPE_CODES='\x1B[94m'           # Escape codes for file prefix
-LINK_PREFIX_ESCAPE_CODES='\x1B[36m'           # Escape codes for link prefix
+DIR_PREFIX_ESCAPE_CODES='\x1b[35m'     # Escape codes for directory prefix
+FILE_PREFIX_ESCAPE_CODES='\x1b[94m'    # Escape codes for file prefix
+LINK_PREFIX_ESCAPE_CODES='\x1b[36m'    # Escape codes for link prefix
 
-DIR_NAME_ESCAPE_CODES=''                      # Escape codes for directory name
-FILE_NAME_ESCAPE_CODES=''                     # Escape codes for file name
-LINK_NAME_ESCAPE_CODES=''                     # Escape codes for link name
+DIR_NAME_ESCAPE_CODES=''               # Escape codes for directory name
+FILE_NAME_ESCAPE_CODES=''              # Escape codes for file name
+LINK_NAME_ESCAPE_CODES=''              # Escape codes for link name
 
-ERROR_PREFIX_ESCAPE_CODES='\x1B[91m'            # Escape codes for error prefix
-ERROR_MESSAGE_ESCAPE_CODES=''                 # Escape codes for error message
+ERROR_PREFIX_ESCAPE_CODES='\x1b[91m'   # Escape codes for error prefix
+ERROR_MESSAGE_ESCAPE_CODES=''          # Escape codes for error message
 
-SUCCESS_PREFIX_ESCAPE_CODES='\x1B[92m'          # Escape codes for success prefix
-SUCCESS_MESSAGE_ESCAPE_CODES=''               # Escape codes for success message
+SUCCESS_PREFIX_ESCAPE_CODES='\x1b[92m' # Escape codes for success prefix
+SUCCESS_MESSAGE_ESCAPE_CODES=''        # Escape codes for success message
+
+WARNING_PREFIX_ESCAPE_CODES='\x1b[93m' # Escape codes for warning prefix
+WARNING_MESSAGE_ESCAPE_CODES=''        # Escape codes for warning message
 
 #
 # Options for ptls script
@@ -47,6 +51,6 @@ LS_MIN_FILE_OFFSET=5                          # Offset between displayed files/d
 #
 # Options for ptpwd script
 #
-PWD_NEXTLINE_MARGIN=2                         # Left margin increment for next lines (can be 0 as well)
-PWD_SHOW_DIR_PREFIX=1                         # If value is 1 - directory prefixes will be displayed
-PWD_LINE_ESCAPE_CODES=''                      # Escape codes for directory arrow symbol
+PWD_NEXTLINE_MARGIN=2            # Left margin increment for next lines (can be 0 as well)
+PWD_SHOW_DIR_PREFIX=1            # If value is 1 - directory prefixes will be displayed
+PWD_LINE_ESCAPE_CODES='\x1b[92m' # Escape codes for directory arrow symbol

--- a/src/ptCp.sh
+++ b/src/ptCp.sh
@@ -3,22 +3,77 @@
 source ~/.local/share/ptSh/config
 test -f ~/.config/ptSh/config && source ~/.config/ptSh/config
 
-RESULT=$(cp "$@" 2>&1)
+CMD="cp"
 
-if [[ $1 == "--help" ]]; then
-    cat <<< "$RESULT"
-    exit
+if [[ -z $1 ]] || [[ $1 == "--help" ]]; then
+  cat <<< "$(command cp --help)"
+  exit 0
+fi
+
+args=""
+typeset -a files && files=()
+
+read -ra words <<<"${@}"
+
+for val in "${words[@]}"; do
+  if [[ $val == "-"* ]]; then
+    args="$args $val"
+  else
+    files+=( "$val" )
+  fi
+done
+
+# trim leading space
+args="${args#"${args%%[![:space:]]*}"}"
+
+# if args contain interactive
+if [[ $args =~ i ]]; then
+  # if file copying to exists
+  if [[ $(readlink -e "${files[1]}") ]]; then
+    read -r -p "$(echo -e "${WARNING_PREFIX_ESCAPE_CODES}${WARNING_PREFIX}\x1B[0mcp: overwrite '${files[1]}'? ")" resp
+    [[ $resp == [yY] ]] || exit 1
+  # if args = '-i'
+    if [[ "${#args}" -eq 2 ]]; then
+      args=""
+    else
+      # if args contain only a pattern like '-iv'
+      if [[ $args =~ ^-[a-zA-Z]+$ ]]; then
+        # strip i leaving '-v'
+        args="${args//i}"
+      # if arg contain space like '-iv -a'
+      elif [[ $args =~ [[:space:]] ]]; then
+        typeset -a aargs && aargs=( "$args" )
+        typeset -a newargs && newargs=()
+        # convert to array for ease
+        for a in "${aargs[@]}"; do
+          if [[ $a =~ i ]]; then
+            # if arg = '-iv'
+            if [[ "${#a}" -gt 2 ]]; then
+              newargs+=( "${a//i}" )
+            # if arg = '-i'
+            else
+              newargs+=( "${a//\-i}" )
+            fi
+          # if arg = '-a'
+          else
+            newargs+=( "${a}" )
+          fi
+        done
+        args="$(printf " %s" "${newargs[@]}")"
+      fi
+    fi
+  fi
 fi
 
 while read -r line; do
-    if [[ "$line" == *" -> "* ]]; then
-        echo -e "${SUCCESS_PREFIX_ESCAPE_CODES}${SUCCESS_PREFIX}\x1B[0m$line"
-    elif [[ -n $line ]];then
-        err=$(echo "$line" | sed "s/$1: //g" | sed 's/^[^:]*://g')
-        echo -ne "${ERROR_PREFIX_ESCAPE_CODES}${ERROR_PREFIX}\x1B[0m"
-        echo -e "${ERROR_MESSAGE_ESCAPE_CODES}$err\x1B[0m"
-    else
-        echo -ne "${SUCCESS_PREFIX_ESCAPE_CODES}${SUCCESS_PREFIX}\x1B[0m"
-        echo -e "${SUCCESS_MESSAGE_ESCAPE_CODES}${SUCCESS_MESSAGE}\x1B[0m"
-    fi 
-done <<< "$RESULT"
+  if [[ "$line" == *" -> "* ]]; then
+      echo -e "${SUCCESS_PREFIX_ESCAPE_CODES}${SUCCESS_PREFIX}\x1B[0m$line"
+  elif [[ -n $line ]];then
+      err=$(echo "$line" | sed "s/$1: //g" | sed 's/^[^:]*://g')
+      echo -ne "${ERROR_PREFIX_ESCAPE_CODES}${ERROR_PREFIX}\x1B[0m"
+      echo -e "${ERROR_MESSAGE_ESCAPE_CODES}$err\x1B[0m"
+  else
+      echo -ne "${SUCCESS_PREFIX_ESCAPE_CODES}${SUCCESS_PREFIX}\x1B[0m"
+      echo -e "${SUCCESS_MESSAGE_ESCAPE_CODES}${SUCCESS_MESSAGE}\x1B[0m"
+  fi
+done < <(eval "$CMD $args ${files[*]}")


### PR DESCRIPTION
Problem: `ptCp.sh` would not display the error message `cp: overwrite 'file.txt'?` if `RESULT` is set to `"$(cp "$@" 2>&1)"`. However, it does display the overwrite message if the redirection of `STDERR` to `STDOUT` is removed. Though, there is no icon.

Solution: Detect if the arguments passed to `cp` contain `-i` (the interactive prompt, asking to overwrite the file). If this is so,  then create our own prompt that is the same message except it has a `WARNING_PREFIX` symbol. If the users response is `[Yy]`, then strip the `-i` argument from the argument list so the user is not prompted with the builtin response and proceed with copying as usual.

There are comments above all of the `if` statements to make it easier to follow. There also may be a better way to do this.